### PR TITLE
Update flutter_clean_calendar.dart

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2020 Carlos Peña
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/flutter_clean_calendar.dart
+++ b/lib/flutter_clean_calendar.dart
@@ -38,6 +38,7 @@ class Calendar extends StatefulWidget {
   final TextStyle bottomBarTextStyle;
   final Color bottomBarArrowColor;
   final Color bottomBarColor;
+  final expandableDateFormat;
 
   Calendar({
     this.onMonthChanged,
@@ -62,6 +63,7 @@ class Calendar extends StatefulWidget {
     this.bottomBarTextStyle,
     this.bottomBarArrowColor,
     this.bottomBarColor,
+    this.expandableDateFormat = "EEEE MMMM dd, yyyy",    
   });
 
   @override
@@ -280,7 +282,7 @@ class _CalendarState extends State<Calendar> {
             children: <Widget>[
               SizedBox(width: 40.0),
               Text(
-                Utils.fullDayFormat(selectedDate),
+                DateFormat(widget.expandableDateFormat, widget.locale).format(_selectedDate),
                 style: widget.bottomBarTextStyle ?? TextStyle(fontSize: 13),
               ),
               IconButton(

--- a/lib/flutter_clean_calendar.dart
+++ b/lib/flutter_clean_calendar.dart
@@ -38,7 +38,7 @@ class Calendar extends StatefulWidget {
   final TextStyle bottomBarTextStyle;
   final Color bottomBarArrowColor;
   final Color bottomBarColor;
-  final expandableDateFormat;
+  final String expandableDateFormat;
 
   Calendar({
     this.onMonthChanged,


### PR DESCRIPTION
This change solve the a problem I found on the expandable date. No matter if you change the locale to other language, this date was always shown in English.
I changed it, using DateFormat instead.

Besides, I add a new property called expandableDateFormat that allow the user choose a format. The default format is "EEEE MMMM dd, yyyy"