### PR TITLE
Avoid double execution of onDateSelected method

### DIFF
--- a/lib/flutter_clean_calendar.dart
+++ b/lib/flutter_clean_calendar.dart
@@ -620,6 +620,9 @@ class _CalendarState extends State<Calendar> {
   void handleSelectedDateAndUserCallback(DateTime day) {
     var firstDayOfCurrentWeek = _firstDayOfWeek(day);
     var lastDayOfCurrentWeek = _lastDayOfWeek(day);
+    // Flag to decide if we should trigger "onDateSelected" callback
+    // This avoids doule executing the callback when selecting a date in the next month
+    bool isCallback = true;
     // Check if the selected day falls into the next month. If this is the case,
     // then we need to additionaly check, if a day in next year was selected.
     if (_selectedDate.month > day.month) {
@@ -629,6 +632,9 @@ class _CalendarState extends State<Calendar> {
       } else {
         previousMonth();
       }
+      // Callback already fired in nextMonth() or previoisMonth(). Dont
+      // execute it again.
+      isCallback = false;
     }
     // Check if the selected day falls into the last month. If this is the case,
     // then we need to additionaly check, if a day in last year was selected.
@@ -639,6 +645,9 @@ class _CalendarState extends State<Calendar> {
       } else {
         nextMonth();
       }
+      // Callback already fired in nextMonth() or previoisMonth(). Dont
+      // execute it again.
+      isCallback = false;
     }
     setState(() {
       _selectedDate = day;
@@ -648,7 +657,10 @@ class _CalendarState extends State<Calendar> {
       selectedMonthsDays = _daysInMonth(day);
       _selectedEvents = widget.events?[_selectedDate] ?? [];
     });
-    _launchDateSelectionCallback(day);
+    // Check, if the callback was already executed before.
+    if (isCallback) {
+      _launchDateSelectionCallback(_selectedDate);
+    }
   }
 
   void _launchDateSelectionCallback(DateTime day) {


### PR DESCRIPTION
This change closes #45.
It avoids double execution of the [obDateSelected] callback, when a date in next month or previous month gets selected. In this case the callback got executed twice, because it is also called from previousMonth() or nextMonth()