### PR TITLE
fixed Null check error when events is not provided

### DIFF
--- a/lib/flutter_clean_calendar.dart
+++ b/lib/flutter_clean_calendar.dart
@@ -245,7 +245,7 @@ class _CalendarState extends State<Calendar> {
             todayColor: widget.todayColor,
             eventColor: widget.eventColor,
             eventDoneColor: widget.eventDoneColor,
-            events: widget.events![day],
+            events: widget.events?[day] ?? [],
             isDayOfWeek: true,
             dayOfWeek: day,
             dayOfWeekStyle: widget.dayOfWeekStyle ??
@@ -298,7 +298,7 @@ class _CalendarState extends State<Calendar> {
                 todayColor: widget.todayColor,
                 eventColor: widget.eventColor,
                 eventDoneColor: widget.eventDoneColor,
-                events: widget.events![day],
+                events: widget.events?[day] ?? [],
                 onDateSelected: () => handleSelectedDateAndUserCallback(day),
                 date: day,
                 dateStyles: configureDateStyle(monthStarted, monthEnded),


### PR DESCRIPTION
 Exception "Null check operator used on a null value" was thrown when building Calendar widget without "events" parameter.